### PR TITLE
A transaction should only be started at the first Transational, not at C...

### DIFF
--- a/imp/src/java/org/gluewine/persistence_jpa_hibernate/impl/SessionAspectProvider.java
+++ b/imp/src/java/org/gluewine/persistence_jpa_hibernate/impl/SessionAspectProvider.java
@@ -350,7 +350,6 @@ public class SessionAspectProvider implements AspectProvider, CommandProvider, C
             synchronized (factoryLocker)
             {
                 Session hibernateSession = factory.openSession();
-                hibernateSession.beginTransaction();
                 session = new HibernateTransactionalSessionImpl(hibernateSession, preProcessors, postProcessors);
                 provider.bindSession(session);
                 session.increaseContextCount();
@@ -373,10 +372,13 @@ public class SessionAspectProvider implements AspectProvider, CommandProvider, C
             synchronized (factoryLocker)
             {
                 Session hibernateSession = factory.openSession();
-                hibernateSession.beginTransaction();
                 session = new HibernateTransactionalSessionImpl(hibernateSession, preProcessors, postProcessors);
                 provider.bindSession(session);
             }
+        }
+        if (session.getReferenceCount() == 0)
+        {
+            session.getHibernateSession().beginTransaction();
         }
 
         if (increase) session.increaseReferenceCount();


### PR DESCRIPTION
Transactions are used inconsistently, leading to exceptions. This commit fixes that.
