### PR TITLE
Don't try to instantiate interfaces.

### DIFF
--- a/imp/src/java/org/gluewine/core/glue/Gluer.java
+++ b/imp/src/java/org/gluewine/core/glue/Gluer.java
@@ -816,14 +816,21 @@ public final class Gluer implements CodeSourceListener, RepositoryListener<CodeS
                     logger.debug("Instantiating class " + cl);
                     Class<?> clazz = loader.loadClass(cl);
 
+                    if (clazz.isInterface())
+                    {
+                        throw new Exception("Not instatiating service for " + cl + " (is an interface).");
+                    }
+
                     Object o = null;
                     if (enhancer == null || AspectProvider.class.isAssignableFrom(clazz))
                     {
                         o = clazz.newInstance();
                         interceptor.registered((AspectProvider) o);
                     }
-
-                    else o = enhancer.getEnhanced(clazz);
+                    else
+                    {
+                        o = enhancer.getEnhanced(clazz);
+                    }
 
                     addService(new Service(o, getServiceId(o), this));
 


### PR DESCRIPTION
When an interface is specified in Gluewine-Services:, this results in the proxy class having Object as its superclass, which results in NoSuchMethodException when any of the interface methods is called.

This change makes Gluer reject such interfaces.
