### PR TITLE
Fix issue with getAnnotation().

### DIFF
--- a/imp/src/java/org/gluewine/utils/AnnotationUtility.java
+++ b/imp/src/java/org/gluewine/utils/AnnotationUtility.java
@@ -74,7 +74,7 @@ public final class AnnotationUtility
         if (res == null)
         {
             Class<?>[] inter = cl.getInterfaces();
-            for (int i = 0; i < inter.length && ann == null; i++)
+            for (int i = 0; i < inter.length && res == null; i++)
                 res = inter[i].getAnnotation(ann);
         }
 


### PR DESCRIPTION
The code couldn't actually ever check for annotations on interfaces, due to the for loop checking on the wrong object.

This was flagged up by findbugs. It hasn't been tested yet.